### PR TITLE
Fix deprecated 'uses' to resolve GitHub Actions build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v2
+        uses: gradle/actions/wrapper-validation@v5
       - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'microsoft'


### PR DESCRIPTION
我注意到原始 CI 流程中 `.github/workflows/build.yml` 的 `validate gradle wrapper` 步骤使用了[弃用](https://github.com/gradle/wrapper-validation-action/blob/main/README.md)的 [`gradle/wrapper-validation-action@v2`](https://github.com/gradle/wrapper-validation-action/tree/releases/v2) 。这会导致 [CI 流程失败](https://github.com/shiroha-233/RoadWeaver/actions/runs/18453215320)。

我将这一步骤更换为推荐的 [`gradle/actions/wrapper-validation@v5`](https://github.com/gradle/actions/tree/main/wrapper-validation) 来修复这个问题。此外，我还将其他几个 v4 版本的步骤升级为 v5，以得到更好的向前兼容性。

这一更改已经在我的 forked repo 中通过了 CI 测试。

----

I noticed that the `validate gradle wrapper` step in `.github/workflows/build.yml` in the original CI process used the action [`gradle/wrapper-validation-action@v2`](https://github.com/gradle/wrapper-validation-action/tree/releases/v2) action, which has been [deprecated](https://github.com/gradle/wrapper-validation-action/blob/main/README.md) and may cause [failures to the CI process](https://github.com/shiroha-233/RoadWeaver/actions/runs/18453215320).

To fix this, I replaced it with the recommended [`gradle/actions/wrapper-validation@v5`](https://github.com/gradle/actions/tree/main/wrapper-validation). Additionally, I upgraded several other v4 actions to v5 for better forward compatibility.

This change has passed CI test in my forked repo.