### PR TITLE
Fix NeoForge duplicate LWJGL module

### DIFF
--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -170,10 +170,9 @@ dependencies {
     }
 
     // LWJGL OpenCL - GPU 加速粗采样
-    // 系统 GPU 驱动提供 OpenCL ICD；模组内嵌 Java binding 与跨平台 LWJGL core JNI，缺少驱动时自动回退 CPU
+    // Minecraft/NeoForge 已提供 org.lwjgl Java 模块；这里只内嵌 OpenCL binding 与跨平台 core JNI 资源。
     compileOnly("org.lwjgl:lwjgl-opencl:3.3.3") { transitive = false }
     include("org.lwjgl:lwjgl-opencl:3.3.3") { transitive = false }
-    include("org.lwjgl:lwjgl:3.3.3") { transitive = false }
     forgeRuntimeLibrary("org.lwjgl:lwjgl-opencl:3.3.3") { transitive = false }
     runtimeOnly("org.lwjgl:lwjgl-opencl:3.3.3") { transitive = false }
     shadowLwjglNatives("org.lwjgl:lwjgl:3.3.3:natives-windows") { transitive = false }


### PR DESCRIPTION
## Summary

- Stop nesting `lwjgl-3.3.3.jar` in the NeoForge artifact.
- Continue nesting the OpenCL binding and packaging the six platform-specific LWJGL core JNI resources.
- Leave Fabric packaging unchanged because its production dedicated server does not otherwise provide the LWJGL core classes.

## Root cause

Minecraft's NeoForge launch already provides the `org.lwjgl` Java module. Nesting a second copy in RoadWeaver makes module-layer resolution fail before mod loading:

```text
java.lang.module.ResolutionException: Module org.eclipse.jetty.http reads more than one module named org.lwjgl
```

This keeps the loader-specific packaging boundary explicit: NeoForge reuses Minecraft's core Java module, while RoadWeaver supplies only the missing OpenCL binding and native fallback resources.

## Verification

- JDK 21 `clean build` passes for common, Fabric, and NeoForge.
- The NeoForge jar contains `META-INF/jars/lwjgl-opencl-3.3.3.jar`, no nested `lwjgl-3.3.3.jar`, and all six x64/arm64 Windows/Linux/macOS core JNI resources.
- A fresh-world NeoForge `runServer` test reached ready, initialized the NVIDIA OpenCL device, compiled 440 nodes / 4 normal noises / 102 splines, passed first-batch CPU/GPU validation, executed the kernel, and saved all dimensions without RoadWeaver, Mixin, or fatal errors.
