### PR TITLE
Fix road generation success when no RoadData is produced

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -12,6 +12,13 @@ dependencies {
 
     // H2 仅用于读取旧版世界数据，运行时由平台模块打包。
     compileOnly("com.h2database:h2:2.2.224") { transitive = false }
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+    testImplementation("org.mockito:mockito-core:5.12.0")
+}
+
+tasks.named('test', Test).configure {
+    useJUnitPlatform()
 }
  
 sourceSets {

--- a/common/src/main/java/net/shiroha233/roadweaver/generation/RoadGenerationService.java
+++ b/common/src/main/java/net/shiroha233/roadweaver/generation/RoadGenerationService.java
@@ -133,8 +133,8 @@ public final class RoadGenerationService {
             if (!modCfg.roadAppearance().roadsEnabled()) return true;
 
             RoadGenerationConfig genCfg = RoadGenerationConfig.from(modCfg);
-            new Road(level, conn, cfg, genCfg).generateRoad(modCfg.pathfindingCost().aStarMaxSteps());
-            return true;
+            return new Road(level, conn, cfg, genCfg)
+                    .generateRoad(modCfg.pathfindingCost().aStarMaxSteps()) != null;
         } catch (Throwable t) {
             return false;
         }

--- a/common/src/test/java/net/shiroha233/roadweaver/generation/RoadGenerationServiceTest.java
+++ b/common/src/test/java/net/shiroha233/roadweaver/generation/RoadGenerationServiceTest.java
@@ -1,0 +1,76 @@
+package net.shiroha233.roadweaver.generation;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.shiroha233.roadweaver.config.ConfigService;
+import net.shiroha233.roadweaver.config.ModConfig;
+import net.shiroha233.roadweaver.config.sub.RoadAppearanceConfig;
+import net.shiroha233.roadweaver.config.sub.RoadGenerationConfig;
+import net.shiroha233.roadweaver.core.model.StructureConnection;
+import net.shiroha233.roadweaver.features.path.config.PathFeatureConfig;
+import net.shiroha233.roadweaver.features.path.pathlogic.core.Road;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RoadGenerationServiceTest {
+
+    @Test
+    void generateTaskFailsWhenRoadGenerationProducesNoRoadData() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+
+        ModConfig modConfig = ConfigService.get();
+        RoadAppearanceConfig roadAppearance = modConfig.roadAppearance();
+        boolean roadsEnabled = roadAppearance.roadsEnabled();
+        boolean allowArtificial = roadAppearance.allowArtificial();
+        boolean allowNatural = roadAppearance.allowNatural();
+
+        try {
+            roadAppearance.setRoadsEnabled(true);
+            roadAppearance.setAllowArtificial(false);
+            roadAppearance.setAllowNatural(false);
+
+            ServerLevel level = mock(ServerLevel.class);
+            RegistryAccess registryAccess = mock(RegistryAccess.class);
+            @SuppressWarnings("unchecked")
+            Registry<ConfiguredFeature<?, ?>> configuredFeatures = mock(Registry.class);
+
+            when(level.dimension()).thenReturn(Level.OVERWORLD);
+            when(level.registryAccess()).thenReturn(registryAccess);
+            when(registryAccess.registryOrThrow(Registries.CONFIGURED_FEATURE)).thenReturn(configuredFeatures);
+
+            StructureConnection connection = new StructureConnection(
+                    BlockPos.ZERO,
+                    new BlockPos(16, 0, 0)
+            );
+
+            Road road = new Road(
+                    level,
+                    connection,
+                    new PathFeatureConfig(),
+                    RoadGenerationConfig.from(modConfig)
+            );
+            assertNull(
+                    road.generateRoad(modConfig.pathfindingCost().aStarMaxSteps()),
+                    "Test setup must make Road.generateRoad() return null"
+            );
+
+            assertFalse(RoadGenerationService.generateTask(level, connection));
+        } finally {
+            roadAppearance.setRoadsEnabled(roadsEnabled);
+            roadAppearance.setAllowArtificial(allowArtificial);
+            roadAppearance.setAllowNatural(allowNatural);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a generation-status inconsistency in `RoadGenerationService.generateTask()`.

`Road.generateRoad()` can legitimately return `null`, but `generateTask()` previously discarded that return value and reported success as long as no exception was thrown. `safeGenerate()` could therefore mark a `StructureConnection` as `COMPLETED` even though no `RoadData` had been produced.

## Changes

- Treat `Road.generateRoad() == null` as an unsuccessful generation attempt.
- Add a regression test that deterministically exercises the real `null` path.
- Add JUnit Jupiter and Mockito as test-only dependencies for the `common` module.

The production change is intentionally minimal:

```java
return new Road(level, conn, cfg, genCfg)
        .generateRoad(modCfg.pathfindingCost().aStarMaxSteps()) != null;
````

Existing exception handling and the existing behavior when roads are globally disabled are unchanged.

## Testing

* Regression test demonstrated the previous bug first (`expected false but was true`).
* Updated regression test passes and explicitly verifies that the test setup makes `Road.generateRoad()` return `null`.
* `:common:test --rerun-tasks`: `BUILD SUCCESSFUL` (1/1 tests).
* `git diff --check`: clean.
* Built the Fabric mod from this branch and loaded it successfully in Minecraft 1.20.1.
* A fresh world could be created without an observed regression.
* The specific `generateRoad() == null` condition was not observed during the manual smoke test.

## Scope

This PR only addresses the incorrect success contract around `Road.generateRoad()`.

It does not change:

* the separate case where `RoadData` is persisted and a later precomputation step fails

Development tracking:
ErikSteiner/RoadWeaver#1
